### PR TITLE
Fix: pg_isready command not found 

### DIFF
--- a/dockerfiles/django/Dockerfile
+++ b/dockerfiles/django/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /code
 ADD requirements.txt /code/
 RUN pip install -r requirements.txt
 RUN apt-get update
+RUN apt-get install -y apt-utils
 RUN apt-get install -y vim
 RUN apt-get install -y dnsutils imagemagick inkscape
 RUN pip install django-adminplus


### PR DESCRIPTION
Docker build command

> Step 13/14 : RUN apt-get install -y postgresql-client
>  ---> Running in dc1c0869eb20
> Reading package lists...
> Building dependency tree...
> Reading state information...
> The following extra packages will be installed:
>   libpq-dev libpq5 postgresql-client-9.4
> Suggested packages:
>   postgresql-doc-9.4 postgresql-9.4
> The following NEW packages will be installed:
>   postgresql-client postgresql-client-9.4
> The following packages will be upgraded:
>   libpq-dev libpq5
> 2 upgraded, 2 newly installed, 0 to remove and 66 not upgraded.
> Need to get 1450 kB of archives.
> After this operation, 4792 kB of additional disk space will be used.
> Get:1 http://security.debian.org/ jessie/updates/main libpq-dev amd64 9.4.19-0+deb8u1 [167 kB]
> Get:2 http://security.debian.org/ jessie/updates/main libpq5 amd64 9.4.19-0+deb8u1 [128 kB]
> Get:3 http://security.debian.org/ jessie/updates/main postgresql-client-9.4 amd64 9.4.19-0+deb8u1 [1102 kB]
> Get:4 http://deb.debian.org/debian/ jessie/main postgresql-client all 9.4+165+deb8u3 [52.4 kB]
> debconf: delaying package configuration, since apt-utils is not installed

After adding `apt-utils`, command pg_isready is properly installed. It seems postgresql-client package is not installed due to this error.